### PR TITLE
feat: pass auth token to ApiService via useApi, closes #79

### DIFF
--- a/app/api/apiService.ts
+++ b/app/api/apiService.ts
@@ -5,10 +5,11 @@ export class ApiService {
   private baseURL: string;
   private defaultHeaders: HeadersInit;
 
-  constructor() {
+  constructor(token?: string) {
     this.baseURL = getApiDomain();
     this.defaultHeaders = {
       "Content-Type": "application/json",
+      ...(token ? { "X-Token": token } : {}),
     };
   }
 

--- a/app/hooks/useApi.ts
+++ b/app/hooks/useApi.ts
@@ -1,6 +1,6 @@
 import { ApiService } from "@/api/apiService";
 import { useMemo } from "react"; // think of usememo like a singleton, it ensures only one instance exists
 
-export const useApi = () => {
-  return useMemo(() => new ApiService(), []); // only if ApiService changes, the memo gets updated and useEffect in app/users/page.tsx gets triggered
+export const useApi = (token?: string) => {
+  return useMemo(() => new ApiService(token), [token]); // only if ApiService changes, the memo gets updated and useEffect in app/users/page.tsx gets triggered
 };


### PR DESCRIPTION
Wires auth token from localStorage into ApiService via useApi hook.
Token is passed as X-Token header on all requests.
Implements #79.