### PR TITLE
Implement blocking of previously used spells between turns

### DIFF
--- a/app/components/battle/AttackInterface.module.css
+++ b/app/components/battle/AttackInterface.module.css
@@ -152,6 +152,33 @@
   color: #aab0c4;
 }
 
+.blocked {
+  opacity: 0.5;
+  filter: grayscale(0.85);
+  border-color: rgba(255, 105, 120, 0.75);
+  box-shadow: 0 0 18px rgba(255, 105, 120, 0.25);
+}
+
+.lockIcon {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 2;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: rgba(23, 22, 34, 0.92);
+  border: 1px solid rgba(255, 105, 120, 0.7);
+  font-size: 0.9rem;
+}
+
+.blockedText {
+  color: #ff6978 !important;
+  font-weight: 800;
+}
+
 .pending {
   border-color: #40e0ff;
   filter: brightness(1.2);

--- a/app/components/battle/AttackInterface.module.css
+++ b/app/components/battle/AttackInterface.module.css
@@ -152,13 +152,6 @@
   color: #aab0c4;
 }
 
-.blocked {
-  opacity: 0.5;
-  filter: grayscale(0.85);
-  border-color: rgba(255, 105, 120, 0.75);
-  box-shadow: 0 0 18px rgba(255, 105, 120, 0.25);
-}
-
 .spellButton.blocked:disabled {
   opacity: 0.5;
   filter: grayscale(0.85);

--- a/app/components/battle/AttackInterface.module.css
+++ b/app/components/battle/AttackInterface.module.css
@@ -159,6 +159,13 @@
   box-shadow: 0 0 18px rgba(255, 105, 120, 0.25);
 }
 
+.spellButton.blocked:disabled {
+  opacity: 0.5;
+  filter: grayscale(0.85);
+  border-color: rgba(255, 105, 120, 0.75);
+  box-shadow: 0 0 18px rgba(255, 105, 120, 0.25);
+}
+
 .lockIcon {
   position: absolute;
   top: 6px;

--- a/app/components/battle/AttackInterface.tsx
+++ b/app/components/battle/AttackInterface.tsx
@@ -25,6 +25,7 @@ interface AttackInterfaceProps {
   rain: BattleRain;
   temperature: BattleTemperature;
   wizardClass: string;
+  disabledSpell?: AttackId | null;
 }
 
 function getModifierSymbol(modifier: number) {
@@ -51,6 +52,7 @@ export default function AttackInterface({
   rain,
   temperature,
   wizardClass,
+  disabledSpell,
 }: AttackInterfaceProps) {
   const [pendingId, setPendingId] = useState<AttackId | null>(null);
   const locked = !isMyTurn || disabled;
@@ -61,7 +63,7 @@ export default function AttackInterface({
   }, [isMyTurn]);
 
   const handleClick = (id: AttackId) => {
-    if (locked || pendingId) return;
+    if (locked || pendingId || disabledSpell === id) return;
     setPendingId(id);
     onAttackSelected(id);
   };
@@ -71,6 +73,7 @@ export default function AttackInterface({
       <div className={styles.spellList}>
         {attacks.map((attack) => {
           const isPending = pendingId === attack.id;
+          const isBlocked = disabledSpell === attack.id;
 
           const modifier = getElementModifier(
             attack.element as BattleElement,
@@ -87,10 +90,16 @@ export default function AttackInterface({
               type="button"
               className={`${styles.spellButton} ${elementClass} ${
                 isPending ? styles.pending : ""
-              }`}
-              disabled={locked || pendingId !== null}
+              } ${isBlocked ? styles.blocked : ""}`}
+              disabled={locked || pendingId !== null || isBlocked}
               onClick={() => handleClick(attack.id)}
             >
+              {isBlocked && (
+                <span className={styles.lockIcon}>
+                  🔒
+                </span>
+              )}
+
               <span
                 className={styles.spellIcon}
                 style={{
@@ -115,6 +124,12 @@ export default function AttackInterface({
                     </span>
                   )}
                 </div>
+
+                {isBlocked && (
+                  <small className={styles.blockedText}>
+                    USED LAST TURN
+                  </small>
+                )}
 
                 <small>{attack.description}</small>
               </span>

--- a/app/games/[gameCode]/battles/page.tsx
+++ b/app/games/[gameCode]/battles/page.tsx
@@ -296,6 +296,7 @@ if (isGameOver) {
     hp: battleState.player1Hp,
     maxHp: battleState.player1MaxHp,
     damage: player1DamageText,
+    disabledSpell: battleState.player1DisabledSpell,
   };
 
   const p2 = {
@@ -304,6 +305,7 @@ if (isGameOver) {
     hp: battleState.player2Hp,
     maxHp: battleState.player2MaxHp,
     damage: player2DamageText,
+    disabledSpell: battleState.player2DisabledSpell,
   };
 
   const me = amIPlayer1 ? p1 : p2;
@@ -365,6 +367,7 @@ if (isGameOver) {
             rain={battleState.rain}
             temperature={battleState.temperature}
             wizardClass={me.wizard}
+            disabledSpell={me.disabledSpell}
           />
         </div>
       </div>

--- a/app/types/battle.ts
+++ b/app/types/battle.ts
@@ -39,6 +39,8 @@ export interface BattleStateDTO {
   player2Username: string;
   player1WizardClass: string;
   player2WizardClass: string;
+  player1DisabledSpell: AttackId | null;
+  player2DisabledSpell: AttackId | null;
 
   location: string;
   rain: "CLEAR" | "RAINING" | null;


### PR DESCRIPTION
A spell, that was used in the last turn, now gets disabled.This prevents players from immediately reusing it. The UI now visually indicates when a spell is blocked, both by disabling the button and by showing a lock icon and text. The backend data structures and props are updated to support this feature.